### PR TITLE
Refactor and Fix: Data Augmantation

### DIFF
--- a/base/base_resultvisualization.py
+++ b/base/base_resultvisualization.py
@@ -110,7 +110,7 @@ class ResultVisualization:
                         latest = int(latest)
                     
                     # 테스트 정보를 모두 가져온다.
-                    test_json = sorted((metrics_path/'test').glob(f'**/*{self.test_dirname}*/*{self.test_filename}*.json'))                    
+                    test_json = sorted((metrics_path/'test').glob(f'**/*{self.test_dirname}*/*{self.test_filename}*.json'))           
                     if len(test_json) >= 1:
                         test_epochs = []
                         for t in test_json:

--- a/data_loader/DA/ColorJitter.py
+++ b/data_loader/DA/ColorJitter.py
@@ -39,7 +39,7 @@ class ColorJitter(BaseHook):
         if self.prob is None: 
             use_data = input_data[0]
             device = use_data.get_device()
-            da_result = self._run(da_result.detach().cpu().clone())
+            da_result = self._run(use_data.detach().cpu().clone())
             if device != -1: da_result = da_result.cuda()
             return (torch.cat((use_data, da_result), 0), )
         # 2. Method for using only one of the original or augmented data.
@@ -64,3 +64,7 @@ class ColorJitter(BaseHook):
             self.writer.add_figure(f'input_{self.type}', show_mix_result(da_data, titles=['Original Data', 'Result']))
             close_all_plots()
         return aug_data
+    
+    def loss(self, loss_ftns, output, target, logit):
+        use_target = torch.cat((target, target), 0) if self.prob is None else target
+        return {'loss': loss_ftns(output, use_target, logit), 'target':use_target}

--- a/data_loader/DA/ColorJitter.py
+++ b/data_loader/DA/ColorJitter.py
@@ -5,22 +5,44 @@ import torch
 from utils import show_mix_result, close_all_plots
 
 class ColorJitter(BaseHook):
-    def __init__(self, prob:float=0.5, writer=None, **aug_args):
+    def __init__(self, prob:float=None, writer=None, **aug_kwargs):
         self.type = 'ColorJitter'
+        if aug_kwargs == {}:
+            raise ValueError('There are no options available for Colorjitter (torchvision.transforms.ColorJitter).')
+        available_options = ['brightness', 'contrast', 'saturation', 'hue']
+        if not any(k in available_options for k in aug_kwargs.keys()):
+            raise ValueError(f'Not an option available in ColorJitter.\nList of available options: {available_options}')
+        for k, v in aug_kwargs.items():
+            aug_kwargs[k] = tuple(v) if type(v) == list else float(v)
         super().__init__(self.type, cols=['None'], writer=writer)
         self.prob = prob
-        self.augmentation = transforms.Compose([transforms.ColorJitter(**aug_args)])
-        # brightness=(0.2,0.8), contrast=(0.2,0.8), saturation=(0.2,0.8),hue=(-0.5, 0.5)
+        self.augmentation = transforms.Compose([transforms.ColorJitter(**aug_kwargs)])
+        # brightness=(0.2,0.8), contrast=(0.2,0.8), saturation=(0.2,0.8), hue=(-0.5, 0.5)
     
     def forward_hook(self, module, input_data, output_data):
+        # 1. Method for using both original and augmented data.
+        if self.prob is None: 
+            device = output.get_device()
+            da_result = self._run(output.detach().cpu().clone())
+            if device != -1: da_result.cuda()
+            return torch.cat((output, da_result), 0)
+        # 2. Method for using only one of the original or augmented data.
         r = np.random.rand(1)
-        if r < self.prob:
+        if r < self.prob: 
             device = output.get_device()
             output = self._run(output.detach().cpu().clone())
             if device != -1: output.cuda()
             return output
     
     def forward_pre_hook(self, module, input_data):
+        # 1. Method for using both original and augmented data.
+        if self.prob is None: 
+            use_data = input_data[0]
+            device = use_data.get_device()
+            da_result = self._run(da_result.detach().cpu().clone())
+            if device != -1: da_result = da_result.cuda()
+            return (torch.cat((use_data, da_result), 0), )
+        # 2. Method for using only one of the original or augmented data.
         r = np.random.rand(1)
         if r < self.prob:
             use_data = input_data[0]
@@ -37,8 +59,8 @@ class ColorJitter(BaseHook):
         
         if self.writer is not None:
             img_cnt = size[0] if size[0] < 5 else 5
-            da_data = [[(data[idx]), (aug_data[idx]), (aug_data[idx])] for idx in range(img_cnt)]
+            da_data = [[data[idx], aug_data[idx]] for idx in range(img_cnt)]
             da_data = torch.as_tensor(np.array(da_data))
-            self.writer.add_figure(f'input_{self.type}', show_mix_result(da_data))
+            self.writer.add_figure(f'input_{self.type}', show_mix_result(da_data, titles=['Original Data', 'Result']))
             close_all_plots()
         return aug_data

--- a/data_loader/DA/cutmix.py
+++ b/data_loader/DA/cutmix.py
@@ -80,10 +80,11 @@ class CutMix(BaseHook):
         bbox_H2 = np.clip(cy + patch_H // 2, 0, H)
         return bbox_W1, bbox_H1, bbox_W2, bbox_H2
     
-    def loss(self, loss_ftns, output, target, logit, loss):
+    def loss(self, loss_ftns, output, target, logit):
         random_index, lam = self.rand_index(), self.lam()
         if random_index is None: return loss
         if len(random_index) != len(target): raise ValueError('Target and the number of shuffled indexes do not match.')
+        basic_loss  = loss_ftns(output, target, logit).item()
         random_loss = loss_ftns(output, target[random_index], logit).item()
-        loss = loss*lam +  random_loss*(1.-lam)
-        return loss
+        loss = basic_loss*lam +  random_loss*(1.-lam)
+        return loss, target

--- a/data_loader/DA/mixup.py
+++ b/data_loader/DA/mixup.py
@@ -57,10 +57,11 @@ class MixUp(BaseHook):
         # loss: lam * criterion(pred, target_a) + (1 - lam) * criterion(pred, target_b)
         return mix_data
     
-    def loss(self, loss_ftns, output, target, logit, loss):
+    def loss(self, loss_ftns, output, target, logit):
         random_index, lam = self.rand_index(), self.lam()
         if random_index is None: return loss
         if len(random_index) != len(target): raise ValueError('Target and the number of shuffled indexes do not match.')
+        basic_loss  = loss_ftns(output, target, logit).item()
         random_loss = loss_ftns(output, target[random_index], logit).item()
-        loss = loss*lam +  random_loss*(1.-lam)
-        return loss
+        loss = basic_loss*lam + random_loss*(1.-lam)
+        return {'loss':loss, 'target':target}

--- a/data_loader/DA/mixup.py
+++ b/data_loader/DA/mixup.py
@@ -9,11 +9,6 @@ class MixUp(BaseHook):
         self.type = 'mixup'
         super().__init__(self.type, cols=['lam', 'rand_index'], writer=writer)
         self.alpha = alpha
-        self.reset()
-
-    def reset(self):
-        self._data.loc[:, 'lam'] = None
-        self._data.loc[:, 'rand_index'] = None
         
     def update(self, batch_size):
         self._data.loc[self.type, 'lam'] = np.random.beta(self.alpha, self.alpha) if self.alpha > 0 else 1.

--- a/model/metric.py
+++ b/model/metric.py
@@ -9,6 +9,7 @@ except:
 from pycm import ConfusionMatrix as pycmCM
 from pycm import ROCCurve
 from base import base_metric, base_class_metric
+import numpy as np
 
 """ 
 All metrics use the one-vs-rest strategy. 
@@ -64,7 +65,9 @@ def AUC_OvR_class(confusion_obj:pycmCM, classes=None, method:str='basic'):
     if method not in ['basic', 'roc']: raise ValueError('The method can only be "basic" or "roc".')
     if method.lower() == 'basic': return base_class_metric('AUC', confusion_obj, classes)
     if confusion_obj.prob_vector is None: raise ValueError('No value for prob vector.')
-    crv = ROCCurve(actual_vector=confusion_obj.actual_vector, probs=confusion_obj.prob_vector, classes=confusion_obj.classes)
+    use_classes = confusion_obj.classes
+    if np.issubdtype(use_classes[0].dtype, np.integer): use_classes = [int(c) for c in use_classes]
+    crv = ROCCurve(actual_vector=confusion_obj.actual_vector, probs=confusion_obj.prob_vector, classes=use_classes)
     if classes is None: return crv.area()
     return {classes[class_idx]:v for class_idx, v in enumerate(crv.area().values())}
         

--- a/runner/tester_fixedSpec.py
+++ b/runner/tester_fixedSpec.py
@@ -139,6 +139,6 @@ class FixedSpecTester(Tester):
                         else: self.writer.add_scalars(new_key, {str(k):v for k, v in new_value.items()})
             
                     # 3. Confusion Matrix
-                    self.writer.set_step(self.test_epoch, f'{self.wirter_mode}_{key}')
+                    self.writer.set_step(self.test_epoch, f'{self.wirter_mode}_{key}', False)
                     self.writer.add_figure('ConfusionMatrix', self._make_a_confusion_matrix(value[self.confusion_key]))
                     close_all_plots()

--- a/runner/trainer.py
+++ b/runner/trainer.py
@@ -268,7 +268,9 @@ class Trainer(BaseTrainer):
         
     def _da_loss(self, output, target, logit, loss):        
         try: loss = self.DA_ftns.loss(self._loss, output, target, logit, loss)
-        except: raise AttributeError('There is no loss function set up. If you need a specific formula, configure a loss function.')
+        except: 
+            # raise AttributeError('Loss function is not defined in the DA class. If you need a specific formula, configure a loss function.')
+            print('Loss function is not defined in the DA class. Thus, using the regular loss calculation formula.')
         self.DA_ftns.reset()
         return loss
     

--- a/runner/trainer.py
+++ b/runner/trainer.py
@@ -6,6 +6,7 @@ from utils import ensure_dir, inf_loop, register_forward_hook_layer, tb_projecto
 from utils import plot_classes_preds, close_all_plots
 import numpy as np
 from copy import deepcopy
+from inspect import signature
 import matplotlib.pyplot as plt
 
 import data_loader.data_augmentation as module_DA
@@ -83,8 +84,8 @@ class Trainer(BaseTrainer):
             # 2. Forward pass: compute predicted outputs by passing inputs to the model
             output = self.model(data)
             logit, predict = torch.max(output, 1)
-            loss = self._loss(output, target, logit)
-            if self.cfg_da is not None: loss = self._da_loss(output, target, logit, loss)
+            if self.cfg_da is None: loss = self._loss(output, target, logit)
+            else: loss, target = self._da_loss(output, target, logit)
                 
             # 3. Backward pass: compute gradient of the loss with respect to model parameters
             if self.accumulation_steps is not None: loss = loss / self.accumulation_steps
@@ -266,13 +267,14 @@ class Trainer(BaseTrainer):
         else: loss =  self.criterion(logit, target.type(torch.DoubleTensor).to(self.device))
         return loss
         
-    def _da_loss(self, output, target, logit, loss):        
-        try: loss = self.DA_ftns.loss(self._loss, output, target, logit, loss)
-        except: 
-            # raise AttributeError('Loss function is not defined in the DA class. If you need a specific formula, configure a loss function.')
-            print('Loss function is not defined in the DA class. Thus, using the regular loss calculation formula.')
+    def _da_loss(self, output, target, logit):     
+        if 'loss' not in dir(self.DA_ftns):
+            raise AttributeError('Loss function is not defined in the DA class. If you need a specific formula, configure a loss function.')
+        result = self.DA_ftns.loss(self._loss, output, target, logit)
+        if not isinstance(result, dict) or result=={} or not all(k in ['loss', 'target'] for k in result.keys()): 
+            raise ValueError('The loss function in the DA class requires passing values as a dictionary with keys "loss" and "target".')
         self.DA_ftns.reset()
-        return loss
+        return result['loss'], result['target']
     
     def _sampling(self, data, target):
         if 'down' in self.sampling_type:


### PR DESCRIPTION
1. Refactor and Fix
   - loss in DA
      - Data may exceed batch size. Add a section to adjust the target accordingly.
      - When calculating loss in the DA class, modify it to return the adjusted target and loss as a dictionary.
   - Fix errors in classes that use mixup and color jitter.
   - Storing objects from a confusion matrix created with pycm
      - Objects saved with a modified class name do not retain the modified class name.
      - When loading the object, check for the modified class name in the JSON and update it accordingly.
      - In FixedSpecConfusionTracker, change labels from False, True back to the original class names due to One vs One.