### PR TITLE
Fix: Modify targets to account for one-hot encoding and correct the loss calculation in DA.

### DIFF
--- a/data_loader/DA/cutmix.py
+++ b/data_loader/DA/cutmix.py
@@ -87,4 +87,4 @@ class CutMix(BaseHook):
         if random_index is None: return basic_loss
         random_loss = loss_ftns(output, target[random_index], logit)
         loss = basic_loss*lam +  random_loss*(1.-lam)
-        return loss, target
+        return {'loss':loss, 'target':target}

--- a/utils/plot_util.py
+++ b/utils/plot_util.py
@@ -34,7 +34,7 @@ def plot_imshow(img, one_channel=False):
         
 def plot_classes_preds(images, labels, preds, probs, idx:int=5, one_channel:bool=False, return_plot:bool=False, show:bool=False):
     close_all_plots()
-    idx = idx if len(images) <= idx else len(images)
+    idx = idx if len(images) >= idx else len(images)
     fig = plt.figure(figsize=(3*idx, 5))
     for i in np.arange(idx):
         ax = fig.add_subplot(1, idx, i+1, xticks=[], yticks=[])


### PR DESCRIPTION
1. Fix
   - On the data used for training and the correct answer (target), modify to account for the case where the correct answer is a one-hot encoding.
   - In DA, modify the loss function to be the same as colorjitter.