### PR TITLE
Refactor and Fix: Some errors in FixedSpecConfusionTracker

### DIFF
--- a/base/base_confusion.py
+++ b/base/base_confusion.py
@@ -154,7 +154,7 @@ class FixedSpecConfusionTracker:
             best_cm = self._createConfusionMatrixobj(pos_labels, pos_probs, thresholds[best_idx], [neg_class_name, pos_class_name])
             best_cm.prob_vector = {'pos_probs':pos_probs, 'all_probs':probability_vector[all_idx, :], 'pos_class_idx': pos_class_idx, 'neg_class_idx': neg_class_idx}
             self._data.loc[(goal, pos_class_name, neg_class_name), 'confusion'] = deepcopy(best_cm)
-            self._data.loc[(goal, pos_class_name, neg_class_name), 'auc'] = roc_dict['auc'][pos_class_idx]
+            self._data.loc[(goal, pos_class_name, neg_class_name), 'auc'] = roc_dict['auc'][list(self.positive_class_indices.keys()).index(pos_class_idx)]
             self._data.loc[(goal, pos_class_name, neg_class_name), 'refer_score'] = tpr[best_idx]
             self._data.loc[(goal, pos_class_name, neg_class_name), 'tag'] = f'FixedSpec-{str(goal).replace("0.", "")}_Positive-{pos_class_name}_Negative-{neg_class_name}'
             

--- a/model/metric.py
+++ b/model/metric.py
@@ -65,9 +65,7 @@ def AUC_OvR_class(confusion_obj:pycmCM, classes=None, method:str='basic'):
     if method not in ['basic', 'roc']: raise ValueError('The method can only be "basic" or "roc".')
     if method.lower() == 'basic': return base_class_metric('AUC', confusion_obj, classes)
     if confusion_obj.prob_vector is None: raise ValueError('No value for prob vector.')
-    use_classes = confusion_obj.classes
-    if np.issubdtype(use_classes[0].dtype, np.integer): use_classes = [int(c) for c in use_classes]
-    crv = ROCCurve(actual_vector=confusion_obj.actual_vector, probs=confusion_obj.prob_vector, classes=use_classes)
+    crv = ROCCurve(actual_vector=confusion_obj.actual_vector, probs=confusion_obj.prob_vector, classes=confusion_obj.classes)
     if classes is None: return crv.area()
     return {classes[class_idx]:v for class_idx, v in enumerate(crv.area().values())}
         

--- a/model/metric.py
+++ b/model/metric.py
@@ -67,11 +67,12 @@ def AUC_OvR_class(confusion_obj:pycmCM, classes=None, method:str='basic'):
     if confusion_obj.prob_vector is None: raise ValueError('No value for prob vector.')
     try:
         label_classes = list(np.unique(confusion_obj.actual_vector))
-        crv = ROCCurve(actual_vector=confusion_obj.actual_vector, probs=confusion_obj.prob_vector, classes=label_classes)
+        crv = ROCCurve(actual_vector=confusion_obj.actual_vector, probs=confusion_obj.prob_vector, classes=confusion_obj.classes)
     except:
         print(confusion_obj.actual_vector[-1])
         print(confusion_obj.prob_vector[-1])
         print(confusion_obj.classes, ' & ', label_classes)
+        raise
     if classes is None: return crv.area()
     return {classes[class_idx]:v for class_idx, v in enumerate(crv.area().values())}
         

--- a/model/metric.py
+++ b/model/metric.py
@@ -65,7 +65,13 @@ def AUC_OvR_class(confusion_obj:pycmCM, classes=None, method:str='basic'):
     if method not in ['basic', 'roc']: raise ValueError('The method can only be "basic" or "roc".')
     if method.lower() == 'basic': return base_class_metric('AUC', confusion_obj, classes)
     if confusion_obj.prob_vector is None: raise ValueError('No value for prob vector.')
-    crv = ROCCurve(actual_vector=confusion_obj.actual_vector, probs=confusion_obj.prob_vector, classes=confusion_obj.classes)
+    try:
+        label_classes = list(np.unique(confusion_obj.actual_vector))
+        crv = ROCCurve(actual_vector=confusion_obj.actual_vector, probs=confusion_obj.prob_vector, classes=label_classes)
+    except:
+        print(confusion_obj.actual_vector[-1])
+        print(confusion_obj.prob_vector[-1])
+        print(confusion_obj.classes, ' & ', label_classes)
     if classes is None: return crv.area()
     return {classes[class_idx]:v for class_idx, v in enumerate(crv.area().values())}
         

--- a/model/plottable_metrics.py
+++ b/model/plottable_metrics.py
@@ -186,7 +186,6 @@ def ROC_OvO(labels, probs, classes:list,
         roc_dict['thresholds'].append(use_roc['thresholds'][use_index])
         roc_dict['actual'].append(use_roc['actual'][use_index])
         roc_dict['prob'].append(use_roc['prob'][use_index])
-    
     plot_kwargs = {'classes': classes, 'pos_neg_pair_indices':roc_dict['pos_neg_idx'],
                    'fpr': roc_dict['fpr'], 'tpr': roc_dict['tpr'], 'auc': roc_dict['auc'], 'return_plot': True}
     if show_average:

--- a/model/plottable_metrics.py
+++ b/model/plottable_metrics.py
@@ -190,8 +190,8 @@ def ROC_OvO(labels, probs, classes:list,
     plot_kwargs = {'classes': classes, 'pos_neg_pair_indices':roc_dict['pos_neg_idx'],
                    'fpr': roc_dict['fpr'], 'tpr': roc_dict['tpr'], 'auc': roc_dict['auc'], 'return_plot': True}
     if show_average:
-        plot_kwargs.update({'macro_pair_indices':cal_pair_list, 'mean_auc': mean_roc_dict['auc'],
-                            'mean_fpr': mean_roc_dict['fpr'], 'mean_tpr': mean_roc_dict['tpr']})
+        plot_kwargs.update({'macro_pair_indices':cal_pair_list, 'macro_auc': mean_roc_dict['auc'],
+                            'macro_fpr': mean_roc_dict['fpr'], 'macro_tpr': mean_roc_dict['tpr']})
     fig = plot_ROC_OvO(**plot_kwargs)
     # return roc curve figure
     if return_result: return roc_dict, fig

--- a/runner/explainer.py
+++ b/runner/explainer.py
@@ -45,10 +45,7 @@ class TorchcamExplainer(BaseExplainer):
         self.device = device
         self.xai_layers = None
         
-        self.explain_model_name = config['arch']['type']
-        if 'deit' in self.explain_model_name.lower(): # 나중에 삭제
-            self.output_dir = Path(str(self.output_dir).replace(self.output_dir_name, f'{self.output_dir_name}_last_conv'))
-            if not self.output_dir.is_dir(): self.output_dir.mkdir(parents=True)       
+        self.explain_model_name = config['arch']['type']      
         self.explainset = explainset
         self.n_samples_per_class = len(explainset[0]['index'])
         self.explain_methods = explain_methods

--- a/utils/output_visualization_util.py
+++ b/utils/output_visualization_util.py
@@ -40,7 +40,8 @@ class ResultFixedVisualization(ResultVisualization):
         
     def _get_test_result(self, run_json, basic_data, basic_column_list):
         te = None
+        latest = run_json['latest'] if 'latest' in list(run_json.keys()) else None
         for test_json, test_epoch in run_json['test'].items():
-            if self.test_file_addtional_name in str(test_json): _, _, te = self._read_df_result(test_json, 'test', test_epoch)
+            if self.test_file_addtional_name in str(test_json): _, _, te = self._read_df_result(test_json, 'test', latest)
         if te is None: raise ValueError(f'Not found {self.test_file_addtional_name} file.')
         return self._list_concat(basic_data, list(te.values())), self._list_concat(basic_column_list, list(te.keys()))

--- a/utils/util.py
+++ b/utils/util.py
@@ -178,6 +178,7 @@ def load_pycm_object(object_path:str):
     # 따라서 변경해주는 작업 진행
     object_classes = [class_name for (class_name, pred_value) in json_obj['Matrix']]
     cm = pycmCM(file=open(object_path, "r"))
-    cm.classes = object_classes
-    cm.table = {cm.classes[cm_idx]:{cm.classes[idx]:v for idx, v in cm_v.items()} for cm_idx, cm_v in enumerate(cm.table.values())}
+    if object_classes != list(cm.classes):
+        cm.classes = object_classes
+        cm.table = {cm.classes[cm_idx]:{cm.classes[idx]:v for idx, v in enumerate(cm_v.keys())} for cm_idx, cm_v in enumerate(cm.table.values())}
     return cm

--- a/utils/util.py
+++ b/utils/util.py
@@ -180,5 +180,5 @@ def load_pycm_object(object_path:str):
     cm = pycmCM(file=open(object_path, "r"))
     if object_classes != list(cm.classes):
         cm.classes = object_classes
-        cm.table = {cm.classes[cm_idx]:{cm.classes[idx]:v for idx, v in enumerate(cm_v.keys())} for cm_idx, cm_v in enumerate(cm.table.values())}
+        cm.table = {cm.classes[cm_idx]:{cm.classes[idx]:v for idx, v in enumerate(cm_v.values())} for cm_idx, cm_v in enumerate(cm.table.values())}
     return cm


### PR DESCRIPTION
1. Refactor
   - In FixedSpecConfusionTracker, modify the prob in the confusion object to include both the prob used during object creation and the actual probability information.
   - Delete unnecessary syntax.
2. Fix
   - Fix parameter names that are incorrect.
   - Modify to access the correct AUC in FixedSpecConfusionTracker.